### PR TITLE
Pin nexuscli version

### DIFF
--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
     - nexus
     - nexus3
     - sonatype
-version: 0.1.0
+version: 0.1.1
 python_versions:
   - "2"
   - "3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 eventlet
-nexus3-cli
+nexus3-cli==1.0.1


### PR DESCRIPTION
Python2 support was dropped in version 1.0.2 (I suspect unintentionally, was probably meant to be 2.x series only).